### PR TITLE
refactor!: use pointers in all json-tagged fields

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -10,41 +10,41 @@ type Agents []Agent
 
 // Agent - Agent struct
 type Agent struct {
-	AgentID               *int                `json:"agentId,omitempty"`
-	AgentName             *string             `json:"agentName,omitempty"`
-	AgentType             *string             `json:"agentType,omitempty"`
-	CountryID             *string             `json:"countryId,omitempty"`
-	ClusterMembers        []ClusterMember     `json:"clusterMembers,omitempty"`
-	IPAddresses           []string            `json:"ipAddresses,omitempty"`
-	Groups                GroupLabels         `json:"groups,omitempty"`
-	Location              *string             `json:"location,omitempty"`
-	ErrorDetails          []AgentErrorDetails `json:"errorDetails,omitempty"`
-	Hostname              *string             `json:"hostname,omitempty"`
-	Prefix                *string             `json:"prefix,omitempty"`
-	Enabled               *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Network               *string             `json:"network,omitempty"`
-	CreatedDate           *string             `json:"createdDate,omitempty"`
-	LastSeen              *string             `json:"lastSeen,omitempty"`
-	AgentState            *string             `json:"agentState,omitempty"`
-	VerifySslCertificates *bool               `json:"verifySslCertificate,omitempty" te:"int-bool"`
-	KeepBrowserCache      *bool               `json:"keepBrowserCache,omitempty" te:"int-bool"`
-	Utilization           *int                `json:"utilization,omitempty"`
-	Ipv6Policy            *string             `json:"IPV6Policy,omitempty"`
-	TargetForTests        *string             `json:"targetForTests,omitempty"`
+	AgentID               *int                 `json:"agentId,omitempty"`
+	AgentName             *string              `json:"agentName,omitempty"`
+	AgentType             *string              `json:"agentType,omitempty"`
+	CountryID             *string              `json:"countryId,omitempty"`
+	ClusterMembers        *[]ClusterMember     `json:"clusterMembers,omitempty"`
+	IPAddresses           *[]string            `json:"ipAddresses,omitempty"`
+	Groups                *GroupLabels         `json:"groups,omitempty"`
+	Location              *string              `json:"location,omitempty"`
+	ErrorDetails          *[]AgentErrorDetails `json:"errorDetails,omitempty"`
+	Hostname              *string              `json:"hostname,omitempty"`
+	Prefix                *string              `json:"prefix,omitempty"`
+	Enabled               *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Network               *string              `json:"network,omitempty"`
+	CreatedDate           *string              `json:"createdDate,omitempty"`
+	LastSeen              *string              `json:"lastSeen,omitempty"`
+	AgentState            *string              `json:"agentState,omitempty"`
+	VerifySslCertificates *bool                `json:"verifySslCertificate,omitempty" te:"int-bool"`
+	KeepBrowserCache      *bool                `json:"keepBrowserCache,omitempty" te:"int-bool"`
+	Utilization           *int                 `json:"utilization,omitempty"`
+	Ipv6Policy            *string              `json:"IPV6Policy,omitempty"`
+	TargetForTests        *string              `json:"targetForTests,omitempty"`
 }
 
 //ClusterMember - ClusterMember struct
 type ClusterMember struct {
-	MemberID          *int     `json:"memberId,omitempty"`
-	Name              *string  `json:"name,omitempty"`
-	IPAddresses       []string `json:"IPAddresses,omitempty"`
-	PublicIPAddresses []string `json:"PublicIPAddresses,omitempty"`
-	Prefix            *string  `json:"Prefix,omitempty"`
-	Network           *string  `json:"network,omitempty"`
-	LastSeen          *string  `json:"lastSeen,omitempty"`
-	AgentState        *string  `json:"agentState,omitempty"`
-	Utilization       *int     `json:"utilization,omitempty"`
-	TargetForTests    *string  `json:"targetForTests,omitempty"`
+	MemberID          *int      `json:"memberId,omitempty"`
+	Name              *string   `json:"name,omitempty"`
+	IPAddresses       *[]string `json:"IPAddresses,omitempty"`
+	PublicIPAddresses *[]string `json:"PublicIPAddresses,omitempty"`
+	Prefix            *string   `json:"Prefix,omitempty"`
+	Network           *string   `json:"network,omitempty"`
+	LastSeen          *string   `json:"lastSeen,omitempty"`
+	AgentState        *string   `json:"agentState,omitempty"`
+	Utilization       *int      `json:"utilization,omitempty"`
+	TargetForTests    *string   `json:"targetForTests,omitempty"`
 }
 
 // AgentErrorDetails - Agent error details

--- a/agent_agent.go
+++ b/agent_agent.go
@@ -9,7 +9,7 @@ import (
 type AgentAgent struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/agent_agent.go
+++ b/agent_agent.go
@@ -8,43 +8,43 @@ import (
 // AgentAgent - test
 type AgentAgent struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                 []Agent      `json:"agents,omitempty"`
-	BGPMeasurements        *bool        `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	BGPMonitors            []BGPMonitor `json:"bgpMonitors,omitempty"`
-	Direction              *string      `json:"direction,omitempty"`
-	DSCP                   *string      `json:"dscp,omitempty"`
-	DSCPID                 *int         `json:"dscpId"`
-	Interval               *int         `json:"interval,omitempty"`
-	MSS                    *int         `json:"mss,omitempty"`
-	NetworkMeasurements    *bool        `json:"networkMeasurements,omitempty" te:"int-bool"`
-	MTUMeasurements        *bool        `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces          *int         `json:"numPathTraces,omitempty"`
-	PathTraceMode          *string      `json:"pathTraceMode,omitempty"`
-	Port                   *int         `json:"port,omitempty"`
-	Protocol               *string      `json:"protocol,omitempty"`
-	TargetAgentID          *int         `json:"targetAgentId,omitempty"`
-	ThroughputDuration     *int         `json:"throughputDuration,omitempty"`
-	ThroughputMeasurements *bool        `json:"throughputMeasurements,omitempty" te:"int-bool"`
-	ThroughputRate         *int         `json:"throughputRate,omitempty"`
-	UsePublicBGP           *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
+	Agents                 *[]Agent      `json:"agents,omitempty"`
+	BGPMeasurements        *bool         `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	BGPMonitors            *[]BGPMonitor `json:"bgpMonitors,omitempty"`
+	Direction              *string       `json:"direction,omitempty"`
+	DSCP                   *string       `json:"dscp,omitempty"`
+	DSCPID                 *int          `json:"dscpId"`
+	Interval               *int          `json:"interval,omitempty"`
+	MSS                    *int          `json:"mss,omitempty"`
+	NetworkMeasurements    *bool         `json:"networkMeasurements,omitempty" te:"int-bool"`
+	MTUMeasurements        *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces          *int          `json:"numPathTraces,omitempty"`
+	PathTraceMode          *string       `json:"pathTraceMode,omitempty"`
+	Port                   *int          `json:"port,omitempty"`
+	Protocol               *string       `json:"protocol,omitempty"`
+	TargetAgentID          *int          `json:"targetAgentId,omitempty"`
+	ThroughputDuration     *int          `json:"throughputDuration,omitempty"`
+	ThroughputMeasurements *bool         `json:"throughputMeasurements,omitempty" te:"int-bool"`
+	ThroughputRate         *int          `json:"throughputRate,omitempty"`
+	UsePublicBGP           *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -79,13 +79,13 @@ func (t *AgentAgent) UnmarshalJSON(data []byte) error {
 // AddAgent - Adds an agent to agent test
 func (t *AgentAgent) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *AgentAgent) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetAgentAgent - Get an agent to agent test

--- a/agent_agent_test.go
+++ b/agent_agent_test.go
@@ -8,15 +8,15 @@ import (
 )
 
 func TestClient_AddAgentAgentAlertRule(t *testing.T) {
-	test := AgentAgent{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := AgentAgent{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
 
 func TestClient_AgentAgentAddAgent(t *testing.T) {
-	test := AgentAgent{TestName: String("test"), Agents: Agents{}}
-	expected := AgentAgent{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := AgentAgent{TestName: String("test"), Agents: &[]Agent{}}
+	expected := AgentAgent{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
@@ -66,8 +66,8 @@ func TestClient_GetAgentAgentJsonError(t *testing.T) {
 }
 
 func TestClient_AddAlertRule(t *testing.T) {
-	test := AgentAgent{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := AgentAgent{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }

--- a/agent_server.go
+++ b/agent_server.go
@@ -10,38 +10,38 @@ import (
 // AgentServer  - Agent to server test
 type AgentServer struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                Agents       `json:"agents,omitempty"`
-	BandwidthMeasurements *bool        `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
-	BGPMeasurements       *bool        `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	BGPMonitors           []BGPMonitor `json:"bgpMonitors,omitempty"`
-	Interval              *int         `json:"interval,omitempty"`
-	MTUMeasurements       *bool        `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NetworkMeasurements   *bool        `json:"networkMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces         *int         `json:"numPathTraces,omitempty"`
-	PathTraceMode         *string      `json:"pathTraceMode,omitempty"`
-	Port                  *int         `json:"port,omitempty"`
-	ProbeMode             *string      `json:"probeMode,omitempty"`
-	Protocol              *string      `json:"protocol,omitempty"`
-	Server                *string      `json:"server,omitempty"`
-	UsePublicBGP          *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
+	Agents                *[]Agent      `json:"agents,omitempty"`
+	BandwidthMeasurements *bool         `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
+	BGPMeasurements       *bool         `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	BGPMonitors           *[]BGPMonitor `json:"bgpMonitors,omitempty"`
+	Interval              *int          `json:"interval,omitempty"`
+	MTUMeasurements       *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NetworkMeasurements   *bool         `json:"networkMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces         *int          `json:"numPathTraces,omitempty"`
+	PathTraceMode         *string       `json:"pathTraceMode,omitempty"`
+	Port                  *int          `json:"port,omitempty"`
+	ProbeMode             *string       `json:"probeMode,omitempty"`
+	Protocol              *string       `json:"protocol,omitempty"`
+	Server                *string       `json:"server,omitempty"`
+	UsePublicBGP          *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -96,13 +96,13 @@ func extractPort(test AgentServer) (AgentServer, error) {
 // AddAgent - Add agent to server test
 func (t *AgentServer) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *AgentServer) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetAgentServer - Get agent to server test

--- a/agent_server.go
+++ b/agent_server.go
@@ -11,7 +11,7 @@ import (
 type AgentServer struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/agent_server_test.go
+++ b/agent_server_test.go
@@ -8,15 +8,15 @@ import (
 )
 
 func TestClient_AddAgentSeverAlertRule(t *testing.T) {
-	test := AgentServer{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := AgentServer{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
 
 func TestClient_AgentServerAddAgent(t *testing.T) {
-	test := AgentServer{TestName: String("test"), Agents: Agents{}}
-	expected := AgentServer{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := AgentServer{TestName: String("test"), Agents: &[]Agent{}}
+	expected := AgentServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
@@ -51,8 +51,8 @@ func TestClient_CreateAgentServer(t *testing.T) {
 }
 
 func TestClient_AddAgentServerAlertRule(t *testing.T) {
-	test := AgentServer{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := AgentServer{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -205,7 +205,7 @@ func TestClient_DeleteAgentServerStatusCode(t *testing.T) {
 
 func TestExtractPort(t *testing.T) {
 	test := AgentServer{
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID: Int(75),
 			},

--- a/agent_test.go
+++ b/agent_test.go
@@ -186,7 +186,7 @@ func TestClient_RemoveAgentFromCluster(t *testing.T) {
 		{
 			AgentID:   Int(1),
 			AgentName: String("test"),
-			ClusterMembers: []ClusterMember{
+			ClusterMembers: &[]ClusterMember{
 				{
 					MemberID: Int(80002),
 					Name:     String("test"),
@@ -210,7 +210,7 @@ func TestClient_AddAgentToCluster(t *testing.T) {
 		{
 			AgentID:   Int(1),
 			AgentName: String("test"),
-			ClusterMembers: []ClusterMember{
+			ClusterMembers: &[]ClusterMember{
 				{
 					MemberID: Int(80002),
 					Name:     String("test"),

--- a/alerts.go
+++ b/alerts.go
@@ -10,20 +10,20 @@ type Alerts []Alert
 
 // Alert - An alert
 type Alert struct {
-	AlertID        *int     `json:"alertId,omitempty"`
-	TestID         *int64   `json:"testId,omitempty"`
-	TestName       *string  `json:"testName,omitempty"`
-	Active         *int     `json:"active,omitempty"`
-	RuleExpression *string  `json:"ruleExpression,omitempty"`
-	DateStart      *string  `json:"dateStart,omitempty"`
-	DateEnd        *string  `json:"dateEnd,omitempty"`
-	ViolationCount *int     `json:"violationCount,omitempty"`
-	RuleName       *string  `json:"ruleName,omitempty"`
-	Permalink      *string  `json:"permalink,omitempty"`
-	Type           *string  `json:"type,omitempty"`
-	Agents         Agents   `json:"agents,omitempty"`
-	Monitors       Monitors `json:"monitors,omitempty"`
-	APILinks       APILinks `json:"apiLinks,omitempty"`
+	AlertID        *int       `json:"alertId,omitempty"`
+	TestID         *int64     `json:"testId,omitempty"`
+	TestName       *string    `json:"testName,omitempty"`
+	Active         *int       `json:"active,omitempty"`
+	RuleExpression *string    `json:"ruleExpression,omitempty"`
+	DateStart      *string    `json:"dateStart,omitempty"`
+	DateEnd        *string    `json:"dateEnd,omitempty"`
+	ViolationCount *int       `json:"violationCount,omitempty"`
+	RuleName       *string    `json:"ruleName,omitempty"`
+	Permalink      *string    `json:"permalink,omitempty"`
+	Type           *string    `json:"type,omitempty"`
+	Agents         *[]Agent   `json:"agents,omitempty"`
+	Monitors       *[]Monitor `json:"monitors,omitempty"`
+	APILinks       *[]APILink `json:"apiLinks,omitempty"`
 }
 
 // AlertRules - list of alert rules
@@ -31,33 +31,33 @@ type AlertRules []AlertRule
 
 // NotificationEmail - Alert Rule Notification Email structure
 type NotificationEmail struct {
-	Message   *string  `json:"message,omitempty"`
-	Recipient []string `json:"recipient,omitempty"`
+	Message   *string   `json:"message,omitempty"`
+	Recipient *[]string `json:"recipient,omitempty"`
 }
 
 // Notification - Alert Rule Notification structure
 type Notification struct {
-	Email NotificationEmail `json:"email,omitempty"`
+	Email *NotificationEmail `json:"email,omitempty"`
 }
 
 // AlertRule - An alert rule
 type AlertRule struct {
-	AlertRuleID             *int         `json:"alertRuleId,omitempty"`
-	AlertType               *string      `json:"alertType,omitempty"`
-	Default                 *int         `json:"default,omitempty"`
-	Direction               *string      `json:"direction,omitempty"`
-	Expression              *string      `json:"expression,omitempty"`
-	IncludeCoveredPrefixes  *int         `json:"includeCoveredPrefixes,omitempty"`
-	MinimumSources          *int         `json:"minimumSources,omitempty"`
-	MinimumSourcesPct       *int         `json:"minimumSourcesPct,omitempty"`
-	NotifyOnClear           *int         `json:"notifyOnClear,omitempty"`
-	RoundsViolatingMode     *string      `json:"roundsViolatingMode,omitempty"`
-	RoundsViolatingOutOf    *int         `json:"roundsViolatingOutOf,omitempty"`
-	RoundsViolatingRequired *int         `json:"roundsViolatingRequired,omitempty"`
-	RuleID                  *int         `json:"ruleId,omitempty"`
-	RuleName                *string      `json:"ruleName,omitempty"`
-	TestIds                 []int        `json:"testIds,omitempty"`
-	Notifications           Notification `json:"notifications,omitempty"`
+	AlertRuleID             *int          `json:"alertRuleId,omitempty"`
+	AlertType               *string       `json:"alertType,omitempty"`
+	Default                 *int          `json:"default,omitempty"`
+	Direction               *string       `json:"direction,omitempty"`
+	Expression              *string       `json:"expression,omitempty"`
+	IncludeCoveredPrefixes  *int          `json:"includeCoveredPrefixes,omitempty"`
+	MinimumSources          *int          `json:"minimumSources,omitempty"`
+	MinimumSourcesPct       *int          `json:"minimumSourcesPct,omitempty"`
+	NotifyOnClear           *int          `json:"notifyOnClear,omitempty"`
+	RoundsViolatingMode     *string       `json:"roundsViolatingMode,omitempty"`
+	RoundsViolatingOutOf    *int          `json:"roundsViolatingOutOf,omitempty"`
+	RoundsViolatingRequired *int          `json:"roundsViolatingRequired,omitempty"`
+	RuleID                  *int          `json:"ruleId,omitempty"`
+	RuleName                *string       `json:"ruleName,omitempty"`
+	TestIds                 *[]int        `json:"testIds,omitempty"`
+	Notifications           *Notification `json:"notifications,omitempty"`
 }
 
 // CreateAlertRule - Create alert rule

--- a/bgp.go
+++ b/bgp.go
@@ -8,28 +8,28 @@ import (
 // BGP - BGP trace test
 type BGP struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	BGPMonitors            []BGPMonitor `json:"bgpMonitors,omitempty"`
-	IncludeCoveredPrefixes *bool        `json:"includeCoveredPrefixes,omitempty" te:"int-bool"`
-	Prefix                 *string      `json:"prefix,omitempty"`
-	UsePublicBGP           *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
+	BGPMonitors            *[]BGPMonitor `json:"bgpMonitors,omitempty"`
+	IncludeCoveredPrefixes *bool         `json:"includeCoveredPrefixes,omitempty" te:"int-bool"`
+	Prefix                 *string       `json:"prefix,omitempty"`
+	UsePublicBGP           *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -64,7 +64,7 @@ func (t *BGP) UnmarshalJSON(data []byte) error {
 // AddAlertRule - Adds an alert to agent test
 func (t *BGP) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetBGP  - get bgp test

--- a/bgp.go
+++ b/bgp.go
@@ -9,7 +9,7 @@ import (
 type BGP struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/bgp_test.go
+++ b/bgp_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestClient_AddBGPAlertRule(t *testing.T) {
-	test := BGP{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := BGP{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := BGP{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := BGP{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -35,13 +35,13 @@ func TestClient_GetBGP(t *testing.T) {
 		Type:          String("bgp"),
 		LiveShare:     Bool(false),
 		Prefix:        String("1.2.3.0/20"),
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -106,14 +106,14 @@ func TestClient_CreateBGP(t *testing.T) {
 		LiveShare:     Bool(false),
 		Prefix:        String("1.2.3.0/20"),
 		AlertsEnabled: Bool(true),
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),

--- a/dns_dnssec.go
+++ b/dns_dnssec.go
@@ -8,27 +8,27 @@ import (
 // DNSSec - DNSSec test
 type DNSSec struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents   []Agent `json:"agents,omitempty"`
-	Domain   *string `json:"domain,omitempty"`
-	Interval *int    `json:"interval,omitempty"`
+	Agents   *[]Agent `json:"agents,omitempty"`
+	Domain   *string  `json:"domain,omitempty"`
+	Interval *int     `json:"interval,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -63,13 +63,13 @@ func (t *DNSSec) UnmarshalJSON(data []byte) error {
 // AddAgent - Add agent to DNSSec test
 func (t *DNSSec) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *DNSSec) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetDNSSec - get DNSSec test

--- a/dns_dnssec.go
+++ b/dns_dnssec.go
@@ -9,7 +9,7 @@ import (
 type DNSSec struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/dns_dnssec_test.go
+++ b/dns_dnssec_test.go
@@ -28,25 +28,25 @@ func TestClient_GetDNSSec(t *testing.T) {
 		Interval:      Int(300),
 		LiveShare:     Bool(false),
 		Domain:        String("webex.com"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		APILinks: []APILink{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -111,26 +111,26 @@ func TestClient_CreateDNSSec(t *testing.T) {
 		LiveShare:     Bool(false),
 		AlertsEnabled: Bool(true),
 		Domain:        String("webex.com"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 
-		APILinks: []APILink{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -181,8 +181,8 @@ func TestClient_DeleteDNSSec(t *testing.T) {
 }
 
 func TestClient_AddDNSSecAlertRule(t *testing.T) {
-	test := DNSSec{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := DNSSec{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := DNSSec{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := DNSSec{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -208,8 +208,8 @@ func TestClient_UpdateDNSSec(t *testing.T) {
 }
 
 func TestDNSSec_AddAgent(t *testing.T) {
-	test := DNSSec{TestName: String("test"), Agents: Agents{}}
-	expected := DNSSec{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := DNSSec{TestName: String("test"), Agents: &[]Agent{}}
+	expected := DNSSec{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/dns_server.go
+++ b/dns_server.go
@@ -14,40 +14,40 @@ type Server struct {
 // DNSServer - dns server test
 type DNSServer struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                Agents       `json:"agents,omitempty"`
-	BandwidthMeasurements *bool        `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
-	BGPMeasurements       *bool        `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	BGPMonitors           []BGPMonitor `json:"bgpMonitors,omitempty"`
-	DNSServers            []Server     `json:"dnsServers,omitempty"`
-	DNSTransportProtocol  *string      `json:"dnsTransportProtocol,omitempty"`
-	Domain                *string      `json:"domain,omitempty"`
-	Interval              *int         `json:"interval,omitempty"`
-	MTUMeasurements       *bool        `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NetworkMeasurements   *bool        `json:"networkMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces         *int         `json:"numPathTraces,omitempty"`
-	PathTraceMode         *string      `json:"pathTraceMode,omitempty"`
-	ProbeMode             *string      `json:"probeMode,omitempty"`
-	Protocol              *string      `json:"protocol,omitempty"`
-	RecursiveQueries      *bool        `json:"recursiveQueries,omitempty" te:"int-bool"`
-	UsePublicBGP          *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
+	Agents                *[]Agent      `json:"agents,omitempty"`
+	BandwidthMeasurements *bool         `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
+	BGPMeasurements       *bool         `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	BGPMonitors           *[]BGPMonitor `json:"bgpMonitors,omitempty"`
+	DNSServers            *[]Server     `json:"dnsServers,omitempty"`
+	DNSTransportProtocol  *string       `json:"dnsTransportProtocol,omitempty"`
+	Domain                *string       `json:"domain,omitempty"`
+	Interval              *int          `json:"interval,omitempty"`
+	MTUMeasurements       *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NetworkMeasurements   *bool         `json:"networkMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces         *int          `json:"numPathTraces,omitempty"`
+	PathTraceMode         *string       `json:"pathTraceMode,omitempty"`
+	ProbeMode             *string       `json:"probeMode,omitempty"`
+	Protocol              *string       `json:"protocol,omitempty"`
+	RecursiveQueries      *bool         `json:"recursiveQueries,omitempty" te:"int-bool"`
+	UsePublicBGP          *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -82,13 +82,13 @@ func (t *DNSServer) UnmarshalJSON(data []byte) error {
 // AddAgent - Add dns server test
 func (t *DNSServer) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *DNSServer) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 //GetDNSServer - get dns server test

--- a/dns_server.go
+++ b/dns_server.go
@@ -15,7 +15,7 @@ type Server struct {
 type DNSServer struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -41,31 +41,31 @@ func TestClient_GetDNSServer(t *testing.T) {
 		Domain:                String("webex.com"),
 		ProbeMode:             String("AUTO"),
 		DNSTransportProtocol:  String("UDP"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		DNSServers: []Server{
+		DNSServers: &[]Server{
 			{
 				ServerID:   Int(123),
 				ServerName: String("1.1.1.1"),
 			},
 		},
-		BGPMonitors: []BGPMonitor{
+		BGPMonitors: &[]BGPMonitor{
 			{
 				MonitorID:   Int(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
@@ -74,7 +74,7 @@ func TestClient_GetDNSServer(t *testing.T) {
 				MonitorType: String("Public"),
 			},
 		},
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -105,8 +105,8 @@ func TestClient_GetDNSServer(t *testing.T) {
 }
 
 func TestClient_AddDnsserverAlertRule(t *testing.T) {
-	test := DNSServer{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := DNSServer{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := DNSServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := DNSServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -159,31 +159,31 @@ func TestClient_CreateDNSServer(t *testing.T) {
 		Domain:                String("webex.com"),
 		ProbeMode:             String("AUTO"),
 		DNSTransportProtocol:  String("UDP"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		DNSServers: []Server{
+		DNSServers: &[]Server{
 			{
 				ServerID:   Int(123),
 				ServerName: String("1.1.1.1"),
 			},
 		},
-		BGPMonitors: []BGPMonitor{
+		BGPMonitors: &[]BGPMonitor{
 			{
 				MonitorID:   Int(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
@@ -192,7 +192,7 @@ func TestClient_CreateDNSServer(t *testing.T) {
 				MonitorType: String("Public"),
 			},
 		},
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -265,8 +265,8 @@ func TestClient_UpdateDNSServer(t *testing.T) {
 }
 
 func TestDNSServer_AddAgent(t *testing.T) {
-	test := DNSServer{TestName: String("test"), Agents: Agents{}}
-	expected := DNSServer{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := DNSServer{TestName: String("test"), Agents: &[]Agent{}}
+	expected := DNSServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/dns_trace.go
+++ b/dns_trace.go
@@ -9,7 +9,7 @@ import (
 type DNSTrace struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/dns_trace.go
+++ b/dns_trace.go
@@ -8,28 +8,28 @@ import (
 // DNSTrace - DNS trace test
 type DNSTrace struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents               []Agent `json:"agents,omitempty"`
-	DNSTransportProtocol *string `json:"dnsTransportProtocol,omitempty"`
-	Domain               *string `json:"domain,omitempty"`
-	Interval             *int    `json:"interval,omitempty"`
+	Agents               *[]Agent `json:"agents,omitempty"`
+	DNSTransportProtocol *string  `json:"dnsTransportProtocol,omitempty"`
+	Domain               *string  `json:"domain,omitempty"`
+	Interval             *int     `json:"interval,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -64,13 +64,13 @@ func (t *DNSTrace) UnmarshalJSON(data []byte) error {
 // AddAgent - Add agent to DNS Trace test
 func (t *DNSTrace) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *DNSTrace) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetDNSTrace - get dns trace test

--- a/dns_trace_test.go
+++ b/dns_trace_test.go
@@ -30,25 +30,25 @@ func TestClient_GetDNSTrace(t *testing.T) {
 		LiveShare:            Bool(false),
 		Domain:               String("webex.com"),
 		DNSTransportProtocol: String("UDP"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -117,26 +117,26 @@ func TestClient_CreateDNSTrace(t *testing.T) {
 		LiveShare:            Bool(false),
 		Domain:               String("webex.com"),
 		DNSTransportProtocol: String("UDP"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -188,8 +188,8 @@ func TestClient_DeleteDNSTrace(t *testing.T) {
 }
 
 func TestClient_AddDnstraceAlertRule(t *testing.T) {
-	test := DNSTrace{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := DNSTrace{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := DNSTrace{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := DNSTrace{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -215,8 +215,8 @@ func TestClient_UpdateDNSTrace(t *testing.T) {
 }
 
 func TestDNSTrace_AddAgent(t *testing.T) {
-	test := DNSTrace{TestName: String("test"), Agents: Agents{}}
-	expected := DNSTrace{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := DNSTrace{TestName: String("test"), Agents: &[]Agent{}}
+	expected := DNSTrace{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/ftp_server.go
+++ b/ftp_server.go
@@ -9,7 +9,7 @@ import (
 type FTPServer struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/ftp_server.go
+++ b/ftp_server.go
@@ -8,42 +8,42 @@ import (
 // FTPServer - ftp server test
 type FTPServer struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents              []Agent `json:"agents,omitempty"`
-	BGPMeasurements     *bool   `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	DownloadLimit       *int    `json:"downloadLimit,omitempty"`
-	FTPTargetTime       *int    `json:"ftpTargetTime,omitempty"`
-	FTPTimeLimit        *int    `json:"ftpTimeLimit,omitempty"`
-	Interval            *int    `json:"interval,omitempty"`
-	MTUMeasurements     *bool   `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NetworkMeasurements *bool   `json:"networkMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces       *int    `json:"numPathTraces,omitempty"`
-	Password            *string `json:"password,omitempty"`
-	PathTraceMode       *string `json:"pathTraceMode,omitempty"`
-	ProbeMode           *string `json:"probeMode,omitempty"`
-	Protocol            *string `json:"protocol,omitempty"`
-	RequestType         *string `json:"requestType,omitempty"`
-	URL                 *string `json:"url,omitempty"`
-	UseActiveFTP        *int    `json:"useActiveFtp,omitempty"`
-	UseExplicitFTPS     *int    `json:"useExplicitFtps,omitempty"`
-	Username            *string `json:"username,omitempty"`
+	Agents              *[]Agent `json:"agents,omitempty"`
+	BGPMeasurements     *bool    `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	DownloadLimit       *int     `json:"downloadLimit,omitempty"`
+	FTPTargetTime       *int     `json:"ftpTargetTime,omitempty"`
+	FTPTimeLimit        *int     `json:"ftpTimeLimit,omitempty"`
+	Interval            *int     `json:"interval,omitempty"`
+	MTUMeasurements     *bool    `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NetworkMeasurements *bool    `json:"networkMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces       *int     `json:"numPathTraces,omitempty"`
+	Password            *string  `json:"password,omitempty"`
+	PathTraceMode       *string  `json:"pathTraceMode,omitempty"`
+	ProbeMode           *string  `json:"probeMode,omitempty"`
+	Protocol            *string  `json:"protocol,omitempty"`
+	RequestType         *string  `json:"requestType,omitempty"`
+	URL                 *string  `json:"url,omitempty"`
+	UseActiveFTP        *int     `json:"useActiveFtp,omitempty"`
+	UseExplicitFTPS     *int     `json:"useExplicitFtps,omitempty"`
+	Username            *string  `json:"username,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -78,13 +78,13 @@ func (t *FTPServer) UnmarshalJSON(data []byte) error {
 // AddAgent - Add ftp server test
 func (t *FTPServer) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *FTPServer) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetFTPServer - get ftp server test

--- a/ftp_server_test.go
+++ b/ftp_server_test.go
@@ -30,19 +30,19 @@ func TestClient_GetFTPServer(t *testing.T) {
 		Interval:      Int(300),
 		URL:           String("webex.com"),
 		ProbeMode:     String("AUTO"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		APILinks: []APILink{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -64,7 +64,7 @@ func TestClient_GetFTPServer(t *testing.T) {
 				Rel:  String("data"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
@@ -116,26 +116,26 @@ func TestClient_CreateFTPServer(t *testing.T) {
 		URL:           String("webex.com"),
 		Protocol:      String("TCP"),
 		ProbeMode:     String("AUTO"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 
-		APILinks: []APILink{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -188,8 +188,8 @@ func TestClient_DeleteFTPServer(t *testing.T) {
 }
 
 func TestClient_AddFTPServerAlertRule(t *testing.T) {
-	test := FTPServer{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := FTPServer{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := FTPServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := FTPServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -215,8 +215,8 @@ func TestClient_UpdateFTPServer(t *testing.T) {
 }
 
 func TestFTPServer_AddAgent(t *testing.T) {
-	test := FTPServer{TestName: String("test"), Agents: Agents{}}
-	expected := FTPServer{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := FTPServer{TestName: String("test"), Agents: &[]Agent{}}
+	expected := FTPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/group_label.go
+++ b/group_label.go
@@ -10,12 +10,12 @@ type GroupLabels []GroupLabel
 
 // GroupLabel - label
 type GroupLabel struct {
-	Name    *string       `json:"name,omitempty"`
-	GroupID *int64        `json:"groupId,omitempty"`
-	Builtin *bool         `json:"builtin,omitempty" te:"int-bool"`
-	Type    *string       `json:"type,omitempty"`
-	Agents  []Agent       `json:"agents,omitempty"`
-	Tests   []GenericTest `json:"tests,omitempty"`
+	Name    *string        `json:"name,omitempty"`
+	GroupID *int64         `json:"groupId,omitempty"`
+	Builtin *bool          `json:"builtin,omitempty" te:"int-bool"`
+	Type    *string        `json:"type,omitempty"`
+	Agents  *[]Agent       `json:"agents,omitempty"`
+	Tests   *[]GenericTest `json:"tests,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures

--- a/http_server.go
+++ b/http_server.go
@@ -22,7 +22,7 @@ type CustomHeaders struct {
 type HTTPServer struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/http_server.go
+++ b/http_server.go
@@ -13,37 +13,37 @@ type HTTPServerResponse struct {
 // CustomHeaders represents the JSON object exchanged for specifying
 // custom HTTP headers in HTTP Server, Page Load, and Web Transaction tests.
 type CustomHeaders struct {
-	Root    map[string]string            `json:"root,omitempty"`
-	All     map[string]string            `json:"all,omitempty"`
-	Domains map[string]map[string]string `json:"domains,omitempty"`
+	Root    *map[string]string            `json:"root,omitempty"`
+	All     *map[string]string            `json:"all,omitempty"`
+	Domains *map[string]map[string]string `json:"domains,omitempty"`
 }
 
 // HTTPServer - a http server test
 type HTTPServer struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                Agents         `json:"agents,omitempty"`
+	Agents                *[]Agent       `json:"agents,omitempty"`
 	AuthType              *string        `json:"authType,omitempty"`
 	BandwidthMeasurements *bool          `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
 	BGPMeasurements       *bool          `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	BGPMonitors           []Monitor      `json:"bgpMonitors,omitempty"`
+	BGPMonitors           *[]Monitor     `json:"bgpMonitors,omitempty"`
 	ClientCertificate     *string        `json:"clientCertificate,omitempty"`
 	ContentRegex          *string        `json:"contentRegex,omitempty"`
 	CustomHeaders         *CustomHeaders `json:"customHeaders,omitempty"`
@@ -51,7 +51,7 @@ type HTTPServer struct {
 	DownloadLimit         *string        `json:"downloadLimit,omitempty"`
 	DNSOverride           *string        `json:"dnsOverride,omitempty"`
 	FollowRedirects       *bool          `json:"followRedirects,omitempty" te:"int-bool"`
-	Headers               []string       `json:"headers,omitempty"`
+	Headers               *[]string      `json:"headers,omitempty"`
 	HTTPVersion           *int           `json:"httpVersion,omitempty"`
 	HTTPTargetTime        *int           `json:"httpTargetTime,omitempty"`
 	HTTPTimeLimit         *int           `json:"httpTimeLimit,omitempty"`
@@ -105,7 +105,7 @@ func (t *HTTPServer) UnmarshalJSON(data []byte) error {
 // AddAgent - add an agent
 func (t *HTTPServer) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 //GetHTTPServer - Get an HTTP Server test

--- a/http_server_test.go
+++ b/http_server_test.go
@@ -45,25 +45,25 @@ func TestClient_GetHTTPServer(t *testing.T) {
 		AuthType:              String("NONE"),
 		ContentRegex:          String(""),
 		ProbeMode:             String("AUTO"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		BGPMonitors: []Monitor{
+		BGPMonitors: &[]Monitor{
 			{
 				MonitorID:   Int(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
@@ -74,7 +74,7 @@ func TestClient_GetHTTPServer(t *testing.T) {
 			},
 		},
 		SSLVersion: String("Auto"),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -156,25 +156,25 @@ func TestClient_CreateHTTPServer(t *testing.T) {
 		AuthType:              String("NONE"),
 		ContentRegex:          String(""),
 		ProbeMode:             String("AUTO"),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		BGPMonitors: []Monitor{
+		BGPMonitors: &[]Monitor{
 			{
 				MonitorID:   Int(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
@@ -185,7 +185,7 @@ func TestClient_CreateHTTPServer(t *testing.T) {
 			},
 		},
 		SSLVersion: String("Auto"),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -257,8 +257,8 @@ func TestClient_UpdateHTTPServer(t *testing.T) {
 }
 
 func TestHTTPServer_AddAgent(t *testing.T) {
-	test := HTTPServer{TestName: String("test"), Agents: Agents{}}
-	expected := HTTPServer{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := HTTPServer{TestName: String("test"), Agents: &[]Agent{}}
+	expected := HTTPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/page_load.go
+++ b/page_load.go
@@ -9,7 +9,7 @@ import (
 type PageLoad struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/page_load.go
+++ b/page_load.go
@@ -8,56 +8,56 @@ import (
 // PageLoad - a page log struct
 type PageLoad struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                Agents        `json:"agents,omitempty"`
-	AuthType              *string       `json:"authType,omitempty"`
-	BandwidthMeasurements *bool         `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
-	BGPMeasurements       *bool         `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	BGPMonitors           []BGPMonitor  `json:"bgpMonitors,omitempty"`
-	ContentRegex          *string       `json:"contentRegex,omitempty"`
-	CustomHeaders         CustomHeaders `json:"customHeaders,omitempty"`
-	FollowRedirects       *bool         `json:"followRedirects,omitempty" te:"int-bool"`
-	HTTPInterval          *int          `json:"httpInterval,omitempty"`
-	HTTPTargetTime        *int          `json:"httpTargetTime,omitempty"`
-	HTTPTimeLimit         *int          `json:"httpTimeLimit,omitempty"`
-	HTTPVersion           *int          `json:"httpVersion,omitempty"`
-	IncludeHeaders        *bool         `json:"includeHeaders,omitempty" te:"int-bool"`
-	Interval              *int          `json:"interval,omitempty"`
-	MTUMeasurements       *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NetworkMeasurements   *bool         `json:"networkMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces         *int          `json:"numPathTraces,omitempty"`
-	PageLoadTargetTime    *int          `json:"pageLoadTargetTime,omitempty"`
-	PageLoadTimeLimit     *int          `json:"pageLoadTimeLimit,omitempty"`
-	Password              *string       `json:"password,omitempty"`
-	PathTraceMode         *string       `json:"pathTraceMode,omitempty"`
-	ProbeMode             *string       `json:"probeMode,omitempty"`
-	Protocol              *string       `json:"protocol,omitempty"`
-	SSLVersion            *string       `json:"sslVersion,omitempty"`
-	SSLVersionID          *int          `json:"sslVersionId,omitempty"`
-	Subinterval           *int          `json:"subinterval,omitempty"`
-	URL                   *string       `json:"url,omitempty"`
-	UseNTLM               *bool         `json:"useNtlm,omitempty" te:"int-bool"`
-	UsePublicBGP          *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
-	UserAgent             *string       `json:"userAgent,omitempty"`
-	Username              *string       `json:"username,omitempty"`
-	VerifyCertificate     *bool         `json:"verifyCertificate,omitempty" te:"int-bool"`
+	Agents                *[]Agent       `json:"agents,omitempty"`
+	AuthType              *string        `json:"authType,omitempty"`
+	BandwidthMeasurements *bool          `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
+	BGPMeasurements       *bool          `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	BGPMonitors           *[]BGPMonitor  `json:"bgpMonitors,omitempty"`
+	ContentRegex          *string        `json:"contentRegex,omitempty"`
+	CustomHeaders         *CustomHeaders `json:"customHeaders,omitempty"`
+	FollowRedirects       *bool          `json:"followRedirects,omitempty" te:"int-bool"`
+	HTTPInterval          *int           `json:"httpInterval,omitempty"`
+	HTTPTargetTime        *int           `json:"httpTargetTime,omitempty"`
+	HTTPTimeLimit         *int           `json:"httpTimeLimit,omitempty"`
+	HTTPVersion           *int           `json:"httpVersion,omitempty"`
+	IncludeHeaders        *bool          `json:"includeHeaders,omitempty" te:"int-bool"`
+	Interval              *int           `json:"interval,omitempty"`
+	MTUMeasurements       *bool          `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NetworkMeasurements   *bool          `json:"networkMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces         *int           `json:"numPathTraces,omitempty"`
+	PageLoadTargetTime    *int           `json:"pageLoadTargetTime,omitempty"`
+	PageLoadTimeLimit     *int           `json:"pageLoadTimeLimit,omitempty"`
+	Password              *string        `json:"password,omitempty"`
+	PathTraceMode         *string        `json:"pathTraceMode,omitempty"`
+	ProbeMode             *string        `json:"probeMode,omitempty"`
+	Protocol              *string        `json:"protocol,omitempty"`
+	SSLVersion            *string        `json:"sslVersion,omitempty"`
+	SSLVersionID          *int           `json:"sslVersionId,omitempty"`
+	Subinterval           *int           `json:"subinterval,omitempty"`
+	URL                   *string        `json:"url,omitempty"`
+	UseNTLM               *bool          `json:"useNtlm,omitempty" te:"int-bool"`
+	UsePublicBGP          *bool          `json:"usePublicBgp,omitempty" te:"int-bool"`
+	UserAgent             *string        `json:"userAgent,omitempty"`
+	Username              *string        `json:"username,omitempty"`
+	VerifyCertificate     *bool          `json:"verifyCertificate,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -92,7 +92,7 @@ func (t *PageLoad) UnmarshalJSON(data []byte) error {
 // AddAgent  - add an aget
 func (t *PageLoad) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 //GetPageLoad - get page load test

--- a/page_load_test.go
+++ b/page_load_test.go
@@ -51,25 +51,25 @@ func TestClient_CreatePageLoad(t *testing.T) {
 		AuthType:              String("NONE"),
 		ProbeMode:             String("AUTO"),
 		ContentRegex:          String(""),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		BGPMonitors: []BGPMonitor{
+		BGPMonitors: &[]BGPMonitor{
 			{
 				MonitorID:   Int(62),
 				IPAddress:   String("2001:1890:111d:1::63"),
@@ -79,7 +79,7 @@ func TestClient_CreatePageLoad(t *testing.T) {
 			},
 		},
 		NumPathTraces: Int(3),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Rel:  String("self"),
 				Href: String("https://api.thousandeyes.com/v6/tests/1226422"),
@@ -158,25 +158,25 @@ func TestClient_GetPageLoad(t *testing.T) {
 		AuthType:              String("NONE"),
 		ProbeMode:             String("AUTO"),
 		ContentRegex:          String(""),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		BGPMonitors: []BGPMonitor{
+		BGPMonitors: &[]BGPMonitor{
 			{
 				MonitorID:   Int(62),
 				IPAddress:   String("2001:1890:111d:1::63"),
@@ -186,7 +186,7 @@ func TestClient_GetPageLoad(t *testing.T) {
 			},
 		},
 		NumPathTraces: Int(3),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Rel:  String("self"),
 				Href: String("https://api.thousandeyes.com/v6/tests/1226422"),
@@ -257,8 +257,8 @@ func TestClient_UpdatePageLoad(t *testing.T) {
 }
 
 func TestPageLoad_AddAgent(t *testing.T) {
-	test := PageLoad{TestName: String("test"), Agents: Agents{}}
-	expected := PageLoad{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := PageLoad{TestName: String("test"), Agents: &[]Agent{}}
+	expected := PageLoad{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/role.go
+++ b/role.go
@@ -7,11 +7,11 @@ import (
 
 // AccountGroupRole - an account group role
 type AccountGroupRole struct {
-	RoleName                 *string      `json:"roleName,omitempty"`
-	RoleID                   *int         `json:"roleId,omitempty"`
-	HasManagementPermissions *bool        `json:"hasManagementPermissions,omitempty" te:"int-bool"`
-	Builtin                  *bool        `json:"builtin,omitempty" te:"int-bool"`
-	Permissions              []Permission `json:"permissions,omitempty"`
+	RoleName                 *string       `json:"roleName,omitempty"`
+	RoleID                   *int          `json:"roleId,omitempty"`
+	HasManagementPermissions *bool         `json:"hasManagementPermissions,omitempty" te:"int-bool"`
+	Builtin                  *bool         `json:"builtin,omitempty" te:"int-bool"`
+	Permissions              *[]Permission `json:"permissions,omitempty"`
 }
 
 // Permission - permission attached to roles

--- a/sip_server.go
+++ b/sip_server.go
@@ -11,7 +11,7 @@ import (
 type SIPServer struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/sip_server.go
+++ b/sip_server.go
@@ -10,39 +10,39 @@ import (
 // SIPServer - SIPServer trace test
 type SIPServer struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                []Agent     `json:"agents,omitempty"`
-	BandwidthMeasurements *bool       `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
-	BGPMeasurements       *bool       `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	Interval              *int        `json:"interval,omitempty"`
-	MTUMeasurements       *bool       `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NetworkMeasurements   *bool       `json:"networkMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces         *int        `json:"numPathTraces,omitempty"`
-	OptionsRegex          *string     `json:"options_regex,omitempty"`
-	PathTraceMode         *string     `json:"pathTraceMode,omitempty"`
-	ProbeMode             *string     `json:"probeMode,omitempty"`
-	RegisterEnabled       *bool       `json:"registerEnabled,omitempty" te:"int-bool"`
-	SIPTargetTime         *int        `json:"sipTargetTime,omitempty"`
-	SIPTimeLimit          *int        `json:"sipTimeLimit,omitempty"`
-	TargetSIPCredentials  SIPAuthData `json:"targetSipCredentials,omitempty"`
-	UsePublicBGP          *bool       `json:"usePublicBgp,omitempty" te:"int-bool"`
+	Agents                *[]Agent     `json:"agents,omitempty"`
+	BandwidthMeasurements *bool        `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
+	BGPMeasurements       *bool        `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	Interval              *int         `json:"interval,omitempty"`
+	MTUMeasurements       *bool        `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NetworkMeasurements   *bool        `json:"networkMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces         *int         `json:"numPathTraces,omitempty"`
+	OptionsRegex          *string      `json:"options_regex,omitempty"`
+	PathTraceMode         *string      `json:"pathTraceMode,omitempty"`
+	ProbeMode             *string      `json:"probeMode,omitempty"`
+	RegisterEnabled       *bool        `json:"registerEnabled,omitempty" te:"int-bool"`
+	SIPTargetTime         *int         `json:"sipTargetTime,omitempty"`
+	SIPTimeLimit          *int         `json:"sipTimeLimit,omitempty"`
+	TargetSIPCredentials  *SIPAuthData `json:"targetSipCredentials,omitempty"`
+	UsePublicBGP          *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -77,13 +77,13 @@ func (t *SIPServer) UnmarshalJSON(data []byte) error {
 // AddAgent - Add agemt to sip server  test
 func (t *SIPServer) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *SIPServer) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleID: Int(id)}
-	t.AlertRules = append(t.AlertRules, alertRule)
+	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
 // GetSIPServer  - get sip server test
@@ -118,16 +118,18 @@ func (c *Client) GetSIPServer(id int) (*SIPServer, error) {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
 	for i := range target["test"] {
-		sipAuth := SIPAuthData{
-			AuthUser:     sipTarget["test"][i].AuthUser,
-			Password:     sipTarget["test"][i].Password,
-			Port:         sipTarget["test"][i].Port,
-			Protocol:     sipTarget["test"][i].Protocol,
-			SIPProxy:     sipTarget["test"][i].SIPProxy,
-			SIPRegistrar: sipTarget["test"][i].SIPRegistrar,
-			User:         sipTarget["test"][i].User,
+		if sipTarget["test"][i].AuthUser != nil {
+			sipAuth := &SIPAuthData{
+				AuthUser:     sipTarget["test"][i].AuthUser,
+				Password:     sipTarget["test"][i].Password,
+				Port:         sipTarget["test"][i].Port,
+				Protocol:     sipTarget["test"][i].Protocol,
+				SIPProxy:     sipTarget["test"][i].SIPProxy,
+				SIPRegistrar: sipTarget["test"][i].SIPRegistrar,
+				User:         sipTarget["test"][i].User,
+			}
+			target["test"][i].TargetSIPCredentials = sipAuth
 		}
-		target["test"][i].TargetSIPCredentials = sipAuth
 	}
 	return &target["test"][0], nil
 }

--- a/sip_server_test.go
+++ b/sip_server_test.go
@@ -28,25 +28,25 @@ func TestClient_GetSIPServer(t *testing.T) {
 		Type:          String("sip-server"),
 		Interval:      Int(300),
 		LiveShare:     Bool(false),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -112,26 +112,26 @@ func TestClient_CreateSIPServer(t *testing.T) {
 		Interval:      Int(300),
 		AlertsEnabled: Bool(true),
 		LiveShare:     Bool(false),
-		Agents: []Agent{
+		Agents: &[]Agent{
 			{
 				AgentID:     Int(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
-				IPAddresses: []string{"135.84.184.153"},
+				IPAddresses: &[]string{"135.84.184.153"},
 				Location:    String("Seattle Area"),
 				Network:     String("Astute Hosting Inc. (AS 54527)"),
 				Prefix:      String("135.84.184.0/22"),
 			},
 		},
-		SharedWithAccounts: []SharedWithAccount{
+		SharedWithAccounts: &[]SharedWithAccount{
 			{
 				AID:              Int(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/1226221"),
 				Rel:  String("self"),
@@ -204,14 +204,14 @@ func TestClient_UpdateSIPServer(t *testing.T) {
 }
 
 func TestSIPServer_AddAgent(t *testing.T) {
-	test := SIPServer{TestName: String("test"), Agents: Agents{}}
-	expected := SIPServer{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := SIPServer{TestName: String("test"), Agents: &[]Agent{}}
+	expected := SIPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
 func TestClient_AddSIPServerAlertRule(t *testing.T) {
-	test := SIPServer{TestName: String("test"), AlertRules: []AlertRule{}}
-	expected := SIPServer{TestName: String("test"), AlertRules: []AlertRule{{RuleID: Int(1)}}}
+	test := SIPServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
+	expected := SIPServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }

--- a/tests.go
+++ b/tests.go
@@ -8,23 +8,24 @@ import (
 // GenericTest - GenericTest struct to represent all test types
 type GenericTest struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+
 	// Fields unique to this test
-	Agents []Agent `json:"agents,omitempty"`
+	Agents *[]Agent `json:"agents,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures

--- a/tests.go
+++ b/tests.go
@@ -9,7 +9,7 @@ import (
 type GenericTest struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/users.go
+++ b/users.go
@@ -7,14 +7,14 @@ import (
 
 // User - a user
 type User struct {
-	Name                 *string            `json:"name,omitempty"`
-	Email                *string            `json:"email,omitempty"`
-	UID                  *int               `json:"uid,omitempty"`
-	LastLogin            *time.Time         `json:"lastLogin,omitempty"`
-	DateRegistered       *time.Time         `json:"dateRegistered,omitempty"`
-	LoginAccountGroup    AccountGroup       `json:"loginAccountGroup,omitempty"`
-	AccountGroupRoles    []AccountGroupRole `json:"accountGroupRoles,omitempty"`
-	AllAccountGroupRoles []AccountGroupRole `json:"allAccountGroupRoles,omitempty"`
+	Name                 *string             `json:"name,omitempty"`
+	Email                *string             `json:"email,omitempty"`
+	UID                  *int                `json:"uid,omitempty"`
+	LastLogin            *time.Time          `json:"lastLogin,omitempty"`
+	DateRegistered       *time.Time          `json:"dateRegistered,omitempty"`
+	LoginAccountGroup    *AccountGroup       `json:"loginAccountGroup,omitempty"`
+	AccountGroupRoles    *[]AccountGroupRole `json:"accountGroupRoles,omitempty"`
+	AllAccountGroupRoles *[]AccountGroupRole `json:"allAccountGroupRoles,omitempty"`
 }
 
 // GetUsers - get users

--- a/voice.go
+++ b/voice.go
@@ -10,38 +10,38 @@ import (
 // RTPStream - RTPStream trace test
 type RTPStream struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents          []Agent      `json:"agents,omitempty"`
-	BGPMeasurements *bool        `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	BGPMonitors     []BGPMonitor `json:"bgpMonitors,omitempty"`
-	Codec           *string      `json:"codec,omitempty"`
-	CodecID         *int         `json:"codecId,omitempty"`
-	DSCP            *string      `json:"dscp,omitempty"`
-	DSCPID          *int         `json:"dscpId,omitempty"`
-	Duration        *int         `json:"duration,omitempty"`
-	Interval        *int         `json:"interval,omitempty"`
-	JitterBuffer    *int         `json:"jitterBuffer,omitempty"`
-	MTUMeasurements *bool        `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces   *int         `json:"numPathTraces,omitempty"`
-	TargetAgentID   *int         `json:"targetAgentId,omitempty"`
-	UsePublicBGP    *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
+	Agents          *[]Agent      `json:"agents,omitempty"`
+	BGPMeasurements *bool         `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	BGPMonitors     *[]BGPMonitor `json:"bgpMonitors,omitempty"`
+	Codec           *string       `json:"codec,omitempty"`
+	CodecID         *int          `json:"codecId,omitempty"`
+	DSCP            *string       `json:"dscp,omitempty"`
+	DSCPID          *int          `json:"dscpId,omitempty"`
+	Duration        *int          `json:"duration,omitempty"`
+	Interval        *int          `json:"interval,omitempty"`
+	JitterBuffer    *int          `json:"jitterBuffer,omitempty"`
+	MTUMeasurements *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces   *int          `json:"numPathTraces,omitempty"`
+	TargetAgentID   *int          `json:"targetAgentId,omitempty"`
+	UsePublicBGP    *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
 	// server field is present in response, but we should not track it.
 	//Server          *string       `json:"server,omitempty"`
 }
@@ -78,7 +78,7 @@ func (t *RTPStream) UnmarshalJSON(data []byte) error {
 // AddAgent - Add agent to voice call  test
 func (t *RTPStream) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // GetRTPStream - get voice call test

--- a/voice.go
+++ b/voice.go
@@ -11,7 +11,7 @@ import (
 type RTPStream struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/voice_call.go
+++ b/voice_call.go
@@ -20,7 +20,7 @@ type SIPAuthData struct {
 type VoiceCall struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/voice_call.go
+++ b/voice_call.go
@@ -19,40 +19,40 @@ type SIPAuthData struct {
 // VoiceCall - VoiceCall trace test
 type VoiceCall struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents               []Agent     `json:"agents,omitempty"`
-	BGPMeasurements      *bool       `json:"bgpMeasurements,omitempty" te:"int-bool"`
-	Codec                *string     `json:"codec,omitempty"`
-	CodecID              *int        `json:"codecId,omitempty"`
-	DSCP                 *string     `json:"dscp,omitempty"`
-	DSCPID               *int        `json:"dscpId,omitempty"`
-	Duration             *int        `json:"duration,omitempty"`
-	Interval             *int        `json:"interval,omitempty"`
-	JitterBuffer         *int        `json:"jitterBuffer,omitempty"`
-	NumPathTraces        *int        `json:"numPathTraces,omitempty"`
-	SIPTargetTime        *int        `json:"sipTargetTime,omitempty"`
-	SIPTimeLimit         *int        `json:"sipTimeLimit,omitempty"`
-	SourceSIPCredentials SIPAuthData `json:"sourceSipCredentials,omitempty"`
-	TargetAgentID        *int        `json:"targetAgentId,omitempty"`
-	TargetSIPCredentials SIPAuthData `json:"targetSipCredentials,omitempty"`
-	UsePublicBGP         *bool       `json:"usePublicBgp,omitempty" te:"int-bool"`
+	Agents               *[]Agent     `json:"agents,omitempty"`
+	BGPMeasurements      *bool        `json:"bgpMeasurements,omitempty" te:"int-bool"`
+	Codec                *string      `json:"codec,omitempty"`
+	CodecID              *int         `json:"codecId,omitempty"`
+	DSCP                 *string      `json:"dscp,omitempty"`
+	DSCPID               *int         `json:"dscpId,omitempty"`
+	Duration             *int         `json:"duration,omitempty"`
+	Interval             *int         `json:"interval,omitempty"`
+	JitterBuffer         *int         `json:"jitterBuffer,omitempty"`
+	NumPathTraces        *int         `json:"numPathTraces,omitempty"`
+	SIPTargetTime        *int         `json:"sipTargetTime,omitempty"`
+	SIPTimeLimit         *int         `json:"sipTimeLimit,omitempty"`
+	SourceSIPCredentials *SIPAuthData `json:"sourceSipCredentials,omitempty"`
+	TargetAgentID        *int         `json:"targetAgentId,omitempty"`
+	TargetSIPCredentials *SIPAuthData `json:"targetSipCredentials,omitempty"`
+	UsePublicBGP         *bool        `json:"usePublicBgp,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures
@@ -87,7 +87,7 @@ func (t *VoiceCall) UnmarshalJSON(data []byte) error {
 // AddAgent - Add agent to voice call  test
 func (t *VoiceCall) AddAgent(id int) {
 	agent := Agent{AgentID: Int(id)}
-	t.Agents = append(t.Agents, agent)
+	*t.Agents = append(*t.Agents, agent)
 }
 
 // GetVoiceCall  - get voice call test

--- a/voice_call_test.go
+++ b/voice_call_test.go
@@ -41,7 +41,7 @@ func TestClient_GetVoiceCall(t *testing.T) {
 		NumPathTraces:   Int(3),
 		DSCP:            String("EF (DSCP 46)"),
 		DSCPID:          Int(46),
-		TargetSIPCredentials: SIPAuthData{
+		TargetSIPCredentials: &SIPAuthData{
 			Protocol:     String("UDP"),
 			AuthUser:     String("1005"),
 			Password:     nil,
@@ -50,7 +50,7 @@ func TestClient_GetVoiceCall(t *testing.T) {
 			SIPRegistrar: String("18.234.180.66"),
 			User:         String("1005"),
 		},
-		SourceSIPCredentials: SIPAuthData{
+		SourceSIPCredentials: &SIPAuthData{
 			Protocol:     String("UDP"),
 			AuthUser:     String("1006"),
 			Password:     nil,
@@ -59,7 +59,7 @@ func TestClient_GetVoiceCall(t *testing.T) {
 			SIPRegistrar: String("18.234.180.66"),
 			User:         String("1006"),
 		},
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 
 			{
 				Rel:  String("self"),
@@ -128,7 +128,7 @@ func TestClient_CreateVoiceCall(t *testing.T) {
 		NumPathTraces:   Int(3),
 		Codec:           String("G.711 @ 64 Kbps"),
 		CodecID:         Int(0),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/814641"),
 				Rel:  String("self"),
@@ -203,8 +203,8 @@ func TestClient_UpdateVoiceCall(t *testing.T) {
 }
 
 func TestVoiceCall_AddAgent(t *testing.T) {
-	test := VoiceCall{TestName: String("test"), Agents: Agents{}}
-	expected := VoiceCall{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := VoiceCall{TestName: String("test"), Agents: &[]Agent{}}
+	expected := VoiceCall{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/voice_test.go
+++ b/voice_test.go
@@ -39,7 +39,7 @@ func TestClient_GetRTPStream(t *testing.T) {
 		DSCP:            String("EF (DSCP 46)"),
 		DSCPID:          Int(46),
 		NumPathTraces:   Int(3),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 
 			{
 				Rel:  String("self"),
@@ -108,7 +108,7 @@ func TestClient_CreateRTPStream(t *testing.T) {
 		NumPathTraces:   Int(3),
 		Codec:           String("G.711 @ 64 Kbps"),
 		CodecID:         Int(0),
-		APILinks: APILinks{
+		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/814641"),
 				Rel:  String("self"),
@@ -183,8 +183,8 @@ func TestClient_UpdateRTPStream(t *testing.T) {
 }
 
 func TestRTPStream_AddAgent(t *testing.T) {
-	test := RTPStream{TestName: String("test"), Agents: Agents{}}
-	expected := RTPStream{TestName: String("test"), Agents: []Agent{{AgentID: Int(1)}}}
+	test := RTPStream{TestName: String("test"), Agents: &[]Agent{}}
+	expected := RTPStream{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/web_transaction.go
+++ b/web_transaction.go
@@ -9,7 +9,7 @@ import (
 type WebTransaction struct {
 	// Common test fields
 	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         *[]AlertRule         `json:"alertRules"`
+	AlertRules         *[]AlertRule         `json:"alertRules,omitempty"`
 	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
 	CreatedBy          *string              `json:"createdBy,omitempty"`
 	CreatedDate        *string              `json:"createdDate,omitempty"`

--- a/web_transaction.go
+++ b/web_transaction.go
@@ -8,53 +8,53 @@ import (
 // WebTransaction - a web transcation test
 type WebTransaction struct {
 	// Common test fields
-	AlertsEnabled      *bool               `json:"alertsEnabled,omitempty" te:"int-bool"`
-	AlertRules         []AlertRule         `json:"alertRules"`
-	APILinks           []APILink           `json:"apiLinks,omitempty"`
-	CreatedBy          *string             `json:"createdBy,omitempty"`
-	CreatedDate        *string             `json:"createdDate,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	Enabled            *bool               `json:"enabled,omitempty" te:"int-bool"`
-	Groups             []GroupLabel        `json:"groups,omitempty"`
-	ModifiedBy         *string             `json:"modifiedBy,omitempty"`
-	ModifiedDate       *string             `json:"modifiedDate,omitempty"`
-	SavedEvent         *bool               `json:"savedEvent,omitempty" te:"int-bool"`
-	SharedWithAccounts []SharedWithAccount `json:"sharedWithAccounts,omitempty"`
-	TestID             *int64              `json:"testId,omitempty"`
-	TestName           *string             `json:"testName,omitempty"`
-	Type               *string             `json:"type,omitempty"`
-	LiveShare          *bool               `json:"liveShare,omitempty" te:"int-bool"`
+	AlertsEnabled      *bool                `json:"alertsEnabled,omitempty" te:"int-bool"`
+	AlertRules         *[]AlertRule         `json:"alertRules"`
+	APILinks           *[]APILink           `json:"apiLinks,omitempty"`
+	CreatedBy          *string              `json:"createdBy,omitempty"`
+	CreatedDate        *string              `json:"createdDate,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	Enabled            *bool                `json:"enabled,omitempty" te:"int-bool"`
+	Groups             *[]GroupLabel        `json:"groups,omitempty"`
+	ModifiedBy         *string              `json:"modifiedBy,omitempty"`
+	ModifiedDate       *string              `json:"modifiedDate,omitempty"`
+	SavedEvent         *bool                `json:"savedEvent,omitempty" te:"int-bool"`
+	SharedWithAccounts *[]SharedWithAccount `json:"sharedWithAccounts,omitempty"`
+	TestID             *int64               `json:"testId,omitempty"`
+	TestName           *string              `json:"testName,omitempty"`
+	Type               *string              `json:"type,omitempty"`
+	LiveShare          *bool                `json:"liveShare,omitempty" te:"int-bool"`
 
 	// Fields unique to this test
-	Agents                Agents        `json:"agents,omitempty"`
-	AuthType              *string       `json:"authType,omitempty"`
-	BandwidthMeasurements *bool         `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
-	ContentRegex          *string       `json:"contentRegex,omitempty"`
-	Credentials           []int         `json:"credentials,omitempty"`
-	CustomHeaders         CustomHeaders `json:"customHeaders,omitempty"`
-	DesiredStatusCode     *string       `json:"desiredStatusCode,omitempty"`
-	HTTPTargetTime        *int          `json:"httpTargetTime,omitempty"`
-	HTTPTimeLimit         *int          `json:"httpTimeLimit,omitempty"`
-	HTTPVersion           *int          `json:"httpVersion,omitempty"`
-	IncludeHeaders        *bool         `json:"includeHeaders,omitempty" te:"int-bool"`
-	Interval              *int          `json:"interval,omitempty"`
-	MTUMeasurements       *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
-	NetworkMeasurements   *bool         `json:"networkMeasurements,omitempty" te:"int-bool"`
-	NumPathTraces         *int          `json:"numPathTraces,omitempty"`
-	Password              *string       `json:"password,omitempty"`
-	PathTraceMode         *string       `json:"pathTraceMode,omitempty"`
-	ProbeMode             *string       `json:"probeMode,omitempty"`
-	Protocol              *string       `json:"protocol,omitempty"`
-	SSLVersionID          *int          `json:"sslVersionId,omitempty"`
-	SubInterval           *int          `json:"subinterval,omitempty"`
-	TargetTime            *int          `json:"targetTime,omitempty"`
-	TimeLimit             *int          `json:"timeLimit,omitempty"`
-	TransactionScript     *string       `json:"transactionScript,omitempty"`
-	URL                   *string       `json:"url,omitempty"`
-	UseNTLM               *bool         `json:"useNtlm,omitempty" te:"int-bool"`
-	UserAgent             *string       `json:"userAgent,omitempty"`
-	Username              *string       `json:"username,omitempty"`
-	VerifyCertificate     *bool         `json:"verifyCertificate,omitempty" te:"int-bool"`
+	Agents                *[]Agent       `json:"agents,omitempty"`
+	AuthType              *string        `json:"authType,omitempty"`
+	BandwidthMeasurements *bool          `json:"bandwidthMeasurements,omitempty" te:"int-bool"`
+	ContentRegex          *string        `json:"contentRegex,omitempty"`
+	Credentials           *[]int         `json:"credentials,omitempty"`
+	CustomHeaders         *CustomHeaders `json:"customHeaders,omitempty"`
+	DesiredStatusCode     *string        `json:"desiredStatusCode,omitempty"`
+	HTTPTargetTime        *int           `json:"httpTargetTime,omitempty"`
+	HTTPTimeLimit         *int           `json:"httpTimeLimit,omitempty"`
+	HTTPVersion           *int           `json:"httpVersion,omitempty"`
+	IncludeHeaders        *bool          `json:"includeHeaders,omitempty" te:"int-bool"`
+	Interval              *int           `json:"interval,omitempty"`
+	MTUMeasurements       *bool          `json:"mtuMeasurements,omitempty" te:"int-bool"`
+	NetworkMeasurements   *bool          `json:"networkMeasurements,omitempty" te:"int-bool"`
+	NumPathTraces         *int           `json:"numPathTraces,omitempty"`
+	Password              *string        `json:"password,omitempty"`
+	PathTraceMode         *string        `json:"pathTraceMode,omitempty"`
+	ProbeMode             *string        `json:"probeMode,omitempty"`
+	Protocol              *string        `json:"protocol,omitempty"`
+	SSLVersionID          *int           `json:"sslVersionId,omitempty"`
+	SubInterval           *int           `json:"subinterval,omitempty"`
+	TargetTime            *int           `json:"targetTime,omitempty"`
+	TimeLimit             *int           `json:"timeLimit,omitempty"`
+	TransactionScript     *string        `json:"transactionScript,omitempty"`
+	URL                   *string        `json:"url,omitempty"`
+	UseNTLM               *bool          `json:"useNtlm,omitempty" te:"int-bool"`
+	UserAgent             *string        `json:"userAgent,omitempty"`
+	Username              *string        `json:"username,omitempty"`
+	VerifyCertificate     *bool          `json:"verifyCertificate,omitempty" te:"int-bool"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures


### PR DESCRIPTION
This contribution extends the concept introduced in #90 to all `json`-tagged fields. 