### PR TITLE
fix(tectl): use pointers for accesing fields

### DIFF
--- a/command/tectl/cmd/agents.go
+++ b/command/tectl/cmd/agents.go
@@ -42,7 +42,13 @@ func getAgents(client *thousandeyes.Client) (*tablewriter.Table, error) {
 	table := TableOuput()
 	table.SetHeader([]string{"Agent Name", "AgentID", "Enabled", "Location", "IpAddresses"})
 	for _, v := range *agents {
-		fields := []string{v.AgentName, strconv.Itoa(v.AgentID), strconv.Itoa(v.Enabled), v.Location, strings.Join(v.IPAddresses, ",")}
+		fields := []string{
+			*v.AgentName,
+			strconv.Itoa(*v.AgentID),
+			strconv.FormatBool(*v.Enabled),
+			*v.Location,
+			strings.Join(*v.IPAddresses, ","),
+		}
 		table.Append(fields)
 	}
 	return table, nil
@@ -60,7 +66,13 @@ func getAgent(client *thousandeyes.Client, id string) (*tablewriter.Table, error
 	}
 	table := TableOuput()
 	table.SetHeader([]string{"Agent Name", "AgentID", "Enabled", "Location", "IpAddresses"})
-	fields := []string{agent.AgentName, strconv.Itoa(agent.AgentID), strconv.Itoa(agent.Enabled), agent.Location, strings.Join(agent.IPAddresses, ",")}
+	fields := []string{
+		*agent.AgentName,
+		strconv.Itoa(*agent.AgentID),
+		strconv.FormatBool(*agent.Enabled),
+		*agent.Location,
+		strings.Join(*agent.IPAddresses, ","),
+	}
 	table.Append(fields)
 	return table, nil
 }

--- a/command/tectl/cmd/tests.go
+++ b/command/tectl/cmd/tests.go
@@ -58,7 +58,12 @@ func getTest(client *thousandeyes.Client, id string) (*tablewriter.Table, error)
 	}
 	table := TableOuput()
 	table.SetHeader([]string{"Test Name", "TestID", "Type", "Enabled"})
-	fields := []string{test.TestName, strconv.Itoa(test.TestID), test.Type, strconv.Itoa(test.Enabled)}
+	fields := []string{
+		*test.TestName,
+		strconv.FormatInt(*test.TestID, 10),
+		*test.Type,
+		strconv.FormatBool(*test.Enabled),
+	}
 	table.Append(fields)
 	return table, nil
 }
@@ -72,7 +77,11 @@ func getTests(client *thousandeyes.Client) (*tablewriter.Table, error) {
 	table := TableOuput()
 	table.SetHeader([]string{"Test Name", "TestID", "Type", "Enabled"})
 	for _, v := range *tests {
-		fields := []string{v.TestName, strconv.Itoa(v.TestID), v.Type, strconv.Itoa(v.Enabled)}
+		fields := []string{
+			*v.TestName,
+			strconv.FormatInt(*v.TestID, 10),
+			*v.Type, strconv.FormatBool(*v.Enabled),
+		}
 		table.Append(fields)
 	}
 	return table, nil


### PR DESCRIPTION
I inadvertently broke `tectl` compilation with #90, #91 and #92. This contribution fixes it.