### PR TITLE
chore: bump module path to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ThousandEyes would like to extend a thank you to William Fleming, John Dyer, and
 
 First, download the source code
 ```cli
-go get github.com/thousandeyes/go-thousandeyes
+go get github.com/thousandeyes/go-thousandeyes/v2
 ```
 
 ## Usage
@@ -38,7 +38,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/thousandeyes/go-thousandeyes"
+	"github.com/thousandeyes/go-thousandeyes/v2"
 )
 
 func main() {

--- a/command/tectl/cmd/agents.go
+++ b/command/tectl/cmd/agents.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/thousandeyes/go-thousandeyes"
+	"github.com/thousandeyes/go-thousandeyes/v2"
 )
 
 func GetAgentsExecute() error {

--- a/command/tectl/cmd/root.go
+++ b/command/tectl/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"github.com/thousandeyes/go-thousandeyes"
+	"github.com/thousandeyes/go-thousandeyes/v2"
 	"os"
 )
 

--- a/command/tectl/cmd/tests.go
+++ b/command/tectl/cmd/tests.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"github.com/thousandeyes/go-thousandeyes"
+	"github.com/thousandeyes/go-thousandeyes/v2"
 )
 
 var TestsCmd = &cobra.Command{

--- a/command/tectl/main.go
+++ b/command/tectl/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/thousandeyes/go-thousandeyes/command/tectl/cmd"
+	"github.com/thousandeyes/go-thousandeyes/v2/command/tectl/cmd"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/thousandeyes/go-thousandeyes
+module github.com/thousandeyes/go-thousandeyes/v2
 
 go 1.13
 


### PR DESCRIPTION
This is required when releasing [breaking changes](https://go.dev/doc/modules/release-workflow#breaking).